### PR TITLE
Update requirement to latest version for py310 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,14 +3,14 @@ asn1crypto==1.4.0
 boto==2.49.0
 certifi==2020.12.5
 # Handle older cffi versions in circleci
-cffi==1.14.4; platform_python_implementation == "CPython"
+cffi==1.15.0; platform_python_implementation == "CPython"
 chardet==4.0.0
 configparser==4.0.2
 # cornice 5.0.0 dropped support for Python 2
 cornice==4.0.1
-cryptography==3.3.1
+cryptography==3.3.2
 enum34==1.1.10
-gevent==21.1.2
+gevent==21.12.0
 gunicorn==19.10.0
 hawkauthlib==2.0.0
 hupper==1.10.2
@@ -18,9 +18,9 @@ idna==2.10
 ipaddress==1.0.23
 konfig==1.1
 Mako==1.1.4
-MarkupSafe==1.1.1
+MarkupSafe==2.0.1
 mozsvc==0.10
-mysqlclient==1.4.6
+mysqlclient==2.1.0
 Paste==3.5.0
 PasteDeploy==2.1.1
 plaster==1.0
@@ -36,9 +36,9 @@ python-dateutil==2.8.1
 python-editor==1.0.4
 repoze.lru==0.7
 requests[security]==2.25.1
-simplejson==3.17.2
+simplejson==3.17.6
 six==1.15.0
-SQLAlchemy==1.3.23
+SQLAlchemy==1.4.29
 testfixtures==6.17.1
 tokenlib==2.0.0
 translationstring==1.4
@@ -46,4 +46,4 @@ urllib3==1.26.3
 venusian==1.2.0
 WebOb==1.8.5
 zope.deprecation==4.4.0
-zope.interface==5.2.0
+zope.interface==5.4.0


### PR DESCRIPTION
## Description

Update requirements as too restrictive (mainly mysqlclient which needs 2.1.0).

## Testing

To be tested through upcoming PR within SynoCommunity.

## Issue(s)

Closes [link](link).
